### PR TITLE
Use replace error code on unicode encoding decoding

### DIFF
--- a/src/webob/multidict.py
+++ b/src/webob/multidict.py
@@ -80,12 +80,12 @@ class MultiDict(MutableMapping):
                 else:
 
                     def decode(b):
-                        return b.encode("utf8").decode(charset)
+                        return b.encode("utf8", errors='replace').decode(charset, errors='replace')
 
             else:
 
                 def decode(b):
-                    return b.decode(charset)
+                    return b.decode(charset, errors='replace')
 
             if field.filename:
                 field.filename = decode(field.filename)

--- a/src/webob/multidict.py
+++ b/src/webob/multidict.py
@@ -80,12 +80,14 @@ class MultiDict(MutableMapping):
                 else:
 
                     def decode(b):
-                        return b.encode("utf8", errors='replace').decode(charset, errors='replace')
+                        return b.encode("utf8", errors="replace").decode(
+                            charset, errors="replace"
+                        )
 
             else:
 
                 def decode(b):
-                    return b.decode(charset, errors='replace')
+                    return b.decode(charset, errors="replace")
 
             if field.filename:
                 field.filename = decode(field.filename)


### PR DESCRIPTION
This is generally unsafe with any charset not properly sent by the client. This seems to happen with a few random clients and we should fail gracefully here instead of throwing a UnicodeDecodeError in the web stack