### PR TITLE
parse_qsl_has no error handling

### DIFF
--- a/src/webob/compat.py
+++ b/src/webob/compat.py
@@ -130,8 +130,8 @@ if PY3:  # pragma: no cover
     def url_unquote(s):
         return unquote(s.encode("ascii")).decode("latin-1")
 
-    def parse_qsl_text(qs, encoding="utf-8"):
-        qs = qs.encode("latin-1")
+    def parse_qsl_text(qs, encoding="utf-8", errors="replace"):
+        qs = qs.encode("latin-1", errors=errors)
         qs = qs.replace(b"+", b" ")
         pairs = [s2 for s1 in qs.split(b"&") for s2 in s1.split(b";") if s2]
         for name_value in pairs:
@@ -140,16 +140,16 @@ if PY3:  # pragma: no cover
                 nv.append("")
             name = unquote(nv[0])
             value = unquote(nv[1])
-            yield (name.decode(encoding), value.decode(encoding))
+            yield (name.decode(encoding, errors=errors), value.decode(encoding, errors=errors))
 
 
 else:
     from urlparse import parse_qsl
 
-    def parse_qsl_text(qs, encoding="utf-8"):
+    def parse_qsl_text(qs, encoding="utf-8", errors="replace"):
         qsl = parse_qsl(qs, keep_blank_values=True, strict_parsing=False)
         for (x, y) in qsl:
-            yield (x.decode(encoding), y.decode(encoding))
+            yield (x.decode(encoding, errors=errors), y.decode(encoding, errors=errors))
 
 
 if PY3:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -23,6 +23,16 @@ class text_Tests(unittest.TestCase):
         self.assertTrue(isinstance(result, text_type))
         self.assertEqual(result, text_type(b"La Pe\xc3\xb1a", "utf-8"))
 
+    def test_parse_qsl_does_not_error(self):
+        from webob.compat import parse_qsl_text, PY2
+        if PY2:
+            qs = b"foo=\xffwut&bar=baz"
+            result = [v for v in parse_qsl_text(qs)]
+        else:
+            qs = str("foo=\xffwut&bar=baz")
+            result = [v for v in parse_qsl_text(qs)]
+        self.assertListEqual([("foo", u"\ufffdwut"), ("bar", "baz")], result)
+
     def test_binary_decoding_error(self):
         self.assertRaises(UnicodeDecodeError, self._callFUT, b"\xff", "utf-8")
 


### PR DESCRIPTION
add additional unicode decode error handling on query string value parsing by default.