### PR TITLE
Handle unicode decoding error on the __str__ representation of a Response

### DIFF
--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -11,6 +11,7 @@ from webob.compat import (
     PY2,
     bytes_,
     native_,
+    text_,
     string_types,
     text_type,
     url_quote,
@@ -395,7 +396,7 @@ class Response(object):
             self.body
         parts += map("%s: %s".__mod__, self.headerlist)
         if not skip_body and self.body:
-            parts += ["", self.body if PY2 else self.text]
+            parts += ["", text_(self.body if PY2 else self.text, self.default_charset, errors="replace")]
         return "\r\n".join(parts)
 
     #

--- a/src/webob/response.py
+++ b/src/webob/response.py
@@ -396,7 +396,14 @@ class Response(object):
             self.body
         parts += map("%s: %s".__mod__, self.headerlist)
         if not skip_body and self.body:
-            parts += ["", text_(self.body if PY2 else self.text, self.default_charset, errors="replace")]
+            parts += [
+                "",
+                text_(
+                    self.body if PY2 else self.text,
+                    self.default_charset,
+                    errors="replace",
+                ),
+            ]
         return "\r\n".join(parts)
 
     #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,7 @@ def serve():
             log.debug("shutting server down")
             server.shutdown()
             worker.join(1)
-            if worker.isAlive():
+            if worker.is_alive():
                 log.warning("worker is hanged")
             else:
                 log.debug("server stopped")

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -173,7 +173,7 @@ def test_content_type_supports_unicode():
 
 
 def test_content_type_mismatch():
-    charset="latin-1"
+    charset = "latin-1"
     resp = Response()
     resp.status_code = 200
     resp.default_charset = charset

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -7,8 +7,7 @@ import pytest
 from webob.request import BaseRequest
 from webob.request import Request
 from webob.response import Response
-from webob.compat import text_
-from webob.compat import bytes_
+from webob.compat import text_, bytes_, PY2
 from webob import cookies
 
 
@@ -171,6 +170,19 @@ def test_content_type_supports_unicode():
     resp = Response()
     resp.content_type = content_type
     assert isinstance(resp.headers["Content-Type"], str)
+
+
+def test_content_type_mismatch():
+    charset="latin-1"
+    resp = Response()
+    resp.status_code = 200
+    resp.default_charset = charset
+    resp.content_type = "text/html"
+    if PY2:
+        resp.body = "foo.bar:\xed\x00\xeb\xef\xeb\xec"
+    else:
+        resp.text = u"foo.bar:\xed\x00\xeb\xef\xeb\xec"
+    assert "foo.bar:\xed\x00\xeb\xef\xeb\xec" in str(resp)
 
 
 @pytest.mark.skipif("sys.version_info < (3, 0)")


### PR DESCRIPTION
- Seems to be another case where the charset is not specified, but contains non default charset characters leading to UnicodeDecodeError being thrown